### PR TITLE
Stream response as and when Neptune provides it

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ func main() {
 }
 ```
 
-Example for streaming the result (Neptune streams 64 rows at a time. go test -v -run ExecuteBulkDataAsync is cmd to run the testcase)
+Example for streaming the result
 ==========
+Neptune provides 64 values per Response that is why Execute at present provides a [] of Response since it waits for all the responses to be retrieved and then provides it.In ExecuteAsync method it takes a channel to provide the Response as request parmeter and provides the Response as and when it is provided by Neptune. The Response are streamed to the caller and once all the Response are provided the channel is closed.
+go test -v -run ExecuteBulkDataAsync is the cmd to run the testcase) 
 ```go
 package main
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func main() {
 
 Example for streaming the result
 ==========
-Neptune provides 64 values per Response that is why Execute at present provides a [] of Response since it waits for all the responses to be retrieved and then provides it.In ExecuteAsync method it takes a channel to provide the Response as request parmeter and provides the Response as and when it is provided by Neptune. The Response are streamed to the caller and once all the Response are provided the channel is closed.
+Neptune provides 64 values per Response that is why Execute at present provides a [] of Response since it waits for all the responses to be retrieved and then provides it.In ExecuteAsync method it takes a channel to provide the Response as request parameter and provides the Response as and when it is provided by Neptune. The Response are streamed to the caller and once all the Responses are provided the channel is closed.
 go test -v -run ExecuteBulkDataAsync is the cmd to run the testcase) 
 ```go
 package main

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ type Client struct {
 	responses              chan []byte
 	results                *sync.Map
 	responseNotifier       *sync.Map // responseNotifier notifies the requester that a response has arrived for the request
-	responseStatusNotifier *sync.Map // responseNotifier notifies the requester that a response has arrived for the request with the code
+	responseStatusNotifier *sync.Map // responseStatusNotifier notifies the requester that a response has arrived for the request with the code
 	sync.RWMutex
 	Errored bool
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/schwartzmx/gremtune
+module github.com/rsrinathr/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rsrinathr/gremtune
+module github.com/schwartzmx/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/gremtune_test.go
+++ b/gremtune_test.go
@@ -80,15 +80,15 @@ func seedBulkData(t *testing.T) {
 	log.Println("Seeding bulk data started...")
 
 	_, err := g.Execute(`
-		g.addV('EmployerBulkData').property(id, '1234_EmployerBulkData').property('timestamp', '2018-07-01T13:37:45-05:00').property('source', 'tree')
+		g.addV('EmployerBulkData').property(id, '1234567890').property('timestamp', '2018-07-01T13:37:45-05:00').property('source', 'tree')
 	`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	//t.Logf("Added EmployerBulkData vertices, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 
-	for i := 1; i < 641; i++ {
-		_, err = g.Execute("g.addV('EmployeeBulkData').property(id, '" + strconv.Itoa(i) + "_EmployeeBulkData').property('timestamp', '2018-07-01T13:37:45-05:00').property('source', 'tree').as('y').addE('employes').from(V('1234_EmployerBulkData')).to('y')")
+	for i := 9001; i < 9641; i++ {
+		_, err = g.Execute("g.addV('EmployeeBulkData').property(id, '" + strconv.Itoa(i) + "').property('timestamp', '2018-07-01T13:37:45-05:00').property('source', 'tree').as('y').addE('employes').from(V('1234567890')).to('y')")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/gremtune_test.go
+++ b/gremtune_test.go
@@ -23,17 +23,15 @@ type BulkResponse struct {
 }
 
 func truncateData(t *testing.T) {
-	log.Println("Removing all data from gremlin server strated...")
+	log.Println("Removing all data from gremlin server started...")
 	_, err := g.Execute(`g.V('1234').drop()`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	//t.Logf("Removed all vertices, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 	_, err = g.Execute(`g.V('2145').drop()`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	//t.Logf("Removed all vertices, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 	log.Println("Removing all data from gremlin server completed...")
 }
 
@@ -56,7 +54,6 @@ func seedData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//t.Logf("Added two vertices and one edge, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 	log.Println("Seeding data completed...")
 }
 
@@ -66,12 +63,10 @@ func truncateBulkData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//t.Logf("Removed all vertices, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 	_, err = g.Execute(`g.V().hasLabel('EmployerBulkData').drop()`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	//t.Logf("Removed all vertices, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 	log.Println("Removing bulk data from gremlin server completed...")
 }
 
@@ -85,14 +80,12 @@ func seedBulkData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//t.Logf("Added EmployerBulkData vertices, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 
 	for i := 9001; i < 9641; i++ {
 		_, err = g.Execute("g.addV('EmployeeBulkData').property(id, '" + strconv.Itoa(i) + "').property('timestamp', '2018-07-01T13:37:45-05:00').property('source', 'tree').as('y').addE('employes').from(V('1234567890')).to('y')")
 		if err != nil {
 			t.Fatal(err)
 		}
-		//t.Logf("Added two vertices and one edge, response: %v+ \n err: %s", string(r[0].Result.Data), err)
 	}
 	log.Println("Seeding bulk data completed...")
 }
@@ -130,7 +123,6 @@ func TestExecuteBulkData(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error returned from server err: %v", err.Error())
 	} else {
-		//t.Logf("Execute get vertex, response: %v \n err: %v", string(r[0].Result.Data), err)
 		nl := new(BulkResponse)
 		datastr := strings.Replace(string(r[0].Result.Data), "@type", "type", -1)
 		datastr = strings.Replace(datastr, "@value", "value", -1)
@@ -146,7 +138,6 @@ func TestExecuteBulkData(t *testing.T) {
 
 func TestExecuteBulkDataAsync(t *testing.T) {
 	seedBulkData(t)
-	//defer truncateBulkData(t)
 	start := time.Now()
 	responseChannel := make(chan AsyncResponse, 2)
 	err := g.ExecuteAsync(`g.V().hasLabel('EmployerBulkData').both('employes').hasLabel('EmployeeBulkData').valueMap(true)`, responseChannel)
@@ -160,7 +151,6 @@ func TestExecuteBulkDataAsync(t *testing.T) {
 		for asyncResponse = range responseChannel {
 			log.Println(fmt.Sprintf("Time it took to get async response: %s response status: %v (206 means partial and 200 final response)", time.Since(start), asyncResponse.Response.Status.Code))
 			count++
-			//t.Logf("Execute get vertex, response: %v \n err: %v", string(r[0].Result.Data), err)
 			nl := new(BulkResponse)
 			datastr := strings.Replace(string(asyncResponse.Response.Result.Data), "@type", "type", -1)
 			datastr = strings.Replace(datastr, "@value", "value", -1)
@@ -169,9 +159,6 @@ func TestExecuteBulkDataAsync(t *testing.T) {
 				t.Errorf("There should only be 64 value, got: %v+", len(nl.Value))
 			}
 			start = time.Now()
-			//			if count ==1 {
-			//				time.Sleep(2 * time.Second)
-			//			}
 		}
 		if count != 10 {
 			t.Errorf("There should only be 10 value, got: %v+", count)

--- a/response.go
+++ b/response.go
@@ -96,7 +96,7 @@ func (c *Client) saveResponse(resp Response, err error) {
 	}
 }
 
-// retrieveResponse retrieves the response saved by saveResponse and send the retrieved reponse to the channel .
+// retrieveResponseAsync retrieves the response saved by saveResponse and send the retrieved reponse to the channel .
 func (c *Client) retrieveResponseAsync(id string, responseChannel chan AsyncResponse) {
 	var responseProcessedIndex int
 	responseNotifier, _ := c.responseNotifier.Load(id)

--- a/response.go
+++ b/response.go
@@ -34,6 +34,12 @@ type Result struct {
 }
 
 // Response structs holds the entire response from requests to the gremlin server
+type AsyncResponse struct {
+	Response     Response `json:"response"`     //Partial Response object
+	ErrorMessage string   `json:"errorMessage"` // Error message if there was an error
+}
+
+// Response structs holds the entire response from requests to the gremlin server
 type Response struct {
 	RequestID string `json:"requestId"`
 	Status    Status `json:"status"`
@@ -79,15 +85,72 @@ func (c *Client) saveResponse(resp Response, err error) {
 	newdata := append(container, resp)       // Create new data container with new data
 	c.results.Store(resp.RequestID, newdata) // Add new data to buffer for future retrieval
 	respNotifier, load := c.responseNotifier.LoadOrStore(resp.RequestID, make(chan error, 1))
+	responseStatusNotifier, load := c.responseStatusNotifier.LoadOrStore(resp.RequestID, make(chan int, 1))
 	_ = load
+	if cap(responseStatusNotifier.(chan int)) > len(responseStatusNotifier.(chan int)) {
+		// Channel is not full so adding the response status to the channel else it will cause the method to wait till the response is read by requester
+		responseStatusNotifier.(chan int) <- resp.Status.Code
+	}
 	if resp.Status.Code != statusPartialContent {
 		respNotifier.(chan error) <- err
 	}
 }
 
+// retrieveResponse retrieves the response saved by saveResponse and send the retrieved reponse to the channel .
+func (c *Client) retrieveResponseAsync(id string, responseChannel chan AsyncResponse) {
+	var responseProcessedIndex int
+	responseNotifier, _ := c.responseNotifier.Load(id)
+	responseStatusNotifier, _ := c.responseStatusNotifier.Load(id)
+	for status := range responseStatusNotifier.(chan int) {
+		_ = status
+		if dataI, ok := c.results.Load(id); ok {
+			d := dataI.([]interface{})
+			// Only retrieve all but one from the partial responses saved in results Map that are not sent to responseChannel
+			for i := responseProcessedIndex; i < len(d)-1; i++ {
+				responseProcessedIndex++
+				asyncResponse := AsyncResponse{}
+				asyncResponse.Response = d[i].(Response)
+				// Send the Partial response object to the responseChannel
+				responseChannel <- asyncResponse
+			}
+		}
+		//Checks to see If there was an Error or full response has been provided by Neptune
+		if len(responseNotifier.(chan error)) > 0 {
+			//Checks to see If there was an Error or will get nil when final reponse has been provided by Neptune
+			err := <-responseNotifier.(chan error)
+			if dataI, ok := c.results.Load(id); ok {
+				d := dataI.([]interface{})
+				// Retrieve all the partial responses that are not sent to responseChannel
+				for i := responseProcessedIndex; i < len(d); i++ {
+					responseProcessedIndex++
+					asyncResponse := AsyncResponse{}
+					asyncResponse.Response = d[i].(Response)
+					//when final partial response it sent it also sends the error message if there was an error on the last partial response retrival
+					if responseProcessedIndex == len(d) && err != nil {
+						asyncResponse.ErrorMessage = err.Error()
+					}
+					// Send the Partial response object to the responseChannel
+					responseChannel <- asyncResponse
+				}
+			}
+			// All the Partial response object including the final one has been sent to the responseChannel
+			break
+		}
+	}
+	// All the Partial response object including the final one has been sent to the responseChannel so closing responseStatusNotifier, responseNotifier, responseChannel and removing all the reponse stored
+	defer close(responseStatusNotifier.(chan int))
+	defer close(responseNotifier.(chan error))
+	defer c.responseNotifier.Delete(id)
+	defer c.responseStatusNotifier.Delete(id)
+	defer c.deleteResponse(id)
+	defer close(responseChannel)
+	return
+}
+
 // retrieveResponse retrieves the response saved by saveResponse.
 func (c *Client) retrieveResponse(id string) (data []Response, err error) {
 	resp, _ := c.responseNotifier.Load(id)
+	responseStatusNotifier, _ := c.responseStatusNotifier.Load(id)
 	err = <-resp.(chan error)
 	if err == nil {
 		if dataI, ok := c.results.Load(id); ok {
@@ -97,7 +160,9 @@ func (c *Client) retrieveResponse(id string) (data []Response, err error) {
 				data[i] = d[i].(Response)
 			}
 			close(resp.(chan error))
+			close(responseStatusNotifier.(chan int))
 			c.responseNotifier.Delete(id)
+			c.responseStatusNotifier.Delete(id)
 			c.deleteResponse(id)
 		}
 	}


### PR DESCRIPTION
Neptune provides 64 values per Response that is why Execute at present provides a [] of Response since it waits for all the responses to be retrieved and then provides it. I have added the ExecuteAsync method that takes a channel to provide the Response as request parameter and provides the Response as and when it is received from Neptune. The Response are streamed to the caller and once all the Response are provided the channel is closed.

Java driver has the Stream option http://tinkerpop.apache.org/javadocs/3.4.0/core/org/apache/tinkerpop/gremlin/driver/ResultSet.html#stream-- 