### PR TITLE
Make Read/Write Buffer Size configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,8 @@ func NewDialer(host string, configs ...DialerConfig) (dialer *Ws) {
 		readingWait:  15 * time.Second,
 		connected:    false,
 		quit:         make(chan struct{}),
+		readBufSize:  8192,
+		writeBufSize: 8192,
 	}
 
 	for _, conf := range configs {

--- a/configuration.go
+++ b/configuration.go
@@ -41,11 +41,10 @@ func SetReadingWait(seconds int) DialerConfig {
 	}
 }
 
-
 //SetBufferSize sets the read/write buffer size
 func SetBufferSize(readBufferSize int, writeBufferSize int) DialerConfig {
 	return func(c *Ws) {
 		c.readBufSize = readBufferSize
-                c.writeBufSize = writeBufferSize
+		c.writeBufSize = writeBufferSize
 	}
 }

--- a/configuration.go
+++ b/configuration.go
@@ -40,3 +40,12 @@ func SetReadingWait(seconds int) DialerConfig {
 		c.readingWait = time.Duration(seconds) * time.Second
 	}
 }
+
+
+//SetBufferSize sets the read/write buffer size
+func SetBufferSize(readBufferSize int, writeBufferSize int) DialerConfig {
+	return func(c *Ws) {
+		c.readBufferSize = readBufferSize
+                c.writeBufferSize = writeBufferSize
+	}
+}

--- a/configuration.go
+++ b/configuration.go
@@ -45,7 +45,7 @@ func SetReadingWait(seconds int) DialerConfig {
 //SetBufferSize sets the read/write buffer size
 func SetBufferSize(readBufferSize int, writeBufferSize int) DialerConfig {
 	return func(c *Ws) {
-		c.readBufferSize = readBufferSize
-                c.writeBufferSize = writeBufferSize
+		c.readBufSize = readBufferSize
+                c.writeBufSize = writeBufferSize
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -38,8 +38,8 @@ type Ws struct {
 	writingWait  time.Duration
 	readingWait  time.Duration
 	timeout      time.Duration
-        readBufSize  int
-        writeBufSize int
+	readBufSize  int
+	writeBufSize int
 	quit         chan struct{}
 	sync.RWMutex
 }

--- a/connection.go
+++ b/connection.go
@@ -52,8 +52,8 @@ type auth struct {
 
 func (ws *Ws) connect() (err error) {
 	d := websocket.Dialer{
-		WriteBufferSize:  ws.readBufSize,
-		ReadBufferSize:   ws.writeBufSize,
+		WriteBufferSize:  ws.writeBufSize,
+		ReadBufferSize:   ws.readBufSize,
 		HandshakeTimeout: ws.timeout, // Timeout or else we'll hang forever and never fail on bad hosts.
 	}
 	ws.conn, _, err = d.Dial(ws.host, http.Header{})

--- a/connection.go
+++ b/connection.go
@@ -38,6 +38,8 @@ type Ws struct {
 	writingWait  time.Duration
 	readingWait  time.Duration
 	timeout      time.Duration
+        readBufSize  int
+        writeBufSize int
 	quit         chan struct{}
 	sync.RWMutex
 }
@@ -50,8 +52,8 @@ type auth struct {
 
 func (ws *Ws) connect() (err error) {
 	d := websocket.Dialer{
-		WriteBufferSize:  1000000,
-		ReadBufferSize:   8192,
+		WriteBufferSize:  ws.readBufSize,
+		ReadBufferSize:   ws.writeBufSize,
 		HandshakeTimeout: ws.timeout, // Timeout or else we'll hang forever and never fail on bad hosts.
 	}
 	ws.conn, _, err = d.Dial(ws.host, http.Header{})

--- a/connection.go
+++ b/connection.go
@@ -50,7 +50,7 @@ type auth struct {
 
 func (ws *Ws) connect() (err error) {
 	d := websocket.Dialer{
-		WriteBufferSize:  8192,
+		WriteBufferSize:  1000000,
 		ReadBufferSize:   8192,
 		HandshakeTimeout: ws.timeout, // Timeout or else we'll hang forever and never fail on bad hosts.
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/schwartzmx/gremtune
+module github.com/weinbergm/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/weinbergm/gremtune
+module github.com/schwartzmx/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible


### PR DESCRIPTION
We came across an issue when using Gremtune with Neptune in that if the query sent to Neptune is larger than 8K (the hard coded buffer size value in gremtune), the request is split into multiple websocket frames and Neptune doesn't seem to support that. It tries processing the part of the query in the first frame and fails. This PR is to make the buffer size configurable, so we can specifically increase the write buffer size to fit our query length.