### PR TITLE
Sessioned_Request for Neptune

### DIFF
--- a/client.go
+++ b/client.go
@@ -179,6 +179,20 @@ func (c *Client) ExecuteWithSession(query string, sessionID string) (resp []Resp
 	return
 }
 
+// ExecuteWithSession formats a raw Gremlin query as part of a session, sends it to Gremlin Server, and returns the result.
+func (c *Client) ExecuteWithSessionAndTimeout(query string, sessionID string, timeout int) (resp []Response, err error) {
+	if c.conn.IsDisposed() {
+		return resp, errors.New("you cannot write on disposed connection")
+	}
+	req, id, err := prepareRequestWithSessionAndTimeout(query, sessionID, timeout)
+	if err != nil {
+		return
+	}
+	resp, err = c.executeReq(req, id)
+	return
+}
+
+
 // CommitSession formats a raw Gremlin query, closes the session, and then the transaction will be commited
 func (c *Client) CommitSession(sessionID string) (resp []Response, err error) {
 	if c.conn.IsDisposed() {

--- a/client.go
+++ b/client.go
@@ -30,6 +30,8 @@ func NewDialer(host string, configs ...DialerConfig) (dialer *Ws) {
 		readingWait:  15 * time.Second,
 		connected:    false,
 		quit:         make(chan struct{}),
+		readBufSize:  8192,
+		writeBufSize: 8192,
 	}
 
 	for _, conf := range configs {

--- a/client.go
+++ b/client.go
@@ -74,7 +74,8 @@ func (c *Client) executeRequest(query string, bindings, rebindings *map[string]s
 	var id string
 	if bindings != nil && rebindings != nil {
 		req, id, err = prepareRequestWithBindings(query, *bindings, *rebindings)
-	} else if len(*sessionID) > 0 {
+		// } else if len(*sessionID) > 0 {
+	} else if sessionID != nil {
 		req, id, err = prepareRequestWithSession(query, *sessionID, *commitSession)
 	} else {
 		req, id, err = prepareRequest(query)
@@ -103,7 +104,8 @@ func (c *Client) executeAsync(query string, bindings, rebindings *map[string]str
 	var id string
 	if bindings != nil && rebindings != nil {
 		req, id, err = prepareRequestWithBindings(query, *bindings, *rebindings)
-	} else if len(*sessionID) > 0 {
+		// } else if len(*sessionID) > 0 {
+	} else if sessionID != nil {
 		req, id, err = prepareRequestWithSession(query, *sessionID, *commitSession)
 	} else {
 		req, id, err = prepareRequest(query)

--- a/client.go
+++ b/client.go
@@ -166,7 +166,7 @@ func (c *Client) ExecuteWithSession(query string, sessionID string) (resp []Resp
 }
 
 // CommitSession formats a raw Gremlin query, closes the session, and then the transaction will be commited
-func (c *Client) CommitSession(query string, sessionID string) (resp []Response, err error) {
+func (c *Client) CommitSession(sessionID string) (resp []Response, err error) {
 	if c.conn.IsDisposed() {
 		return resp, errors.New("you cannot write on disposed connection")
 	}

--- a/client.go
+++ b/client.go
@@ -153,6 +153,16 @@ func (c *Client) ExecuteWithBindings(query string, bindings, rebindings map[stri
 	return
 }
 
+// ExecuteWithSession formats a raw Gremlin query as part of a session, sends it to Gremlin Server, and returns the result.
+func (c *Client) ExecuteWithSession(query string, sessionID string, commitSession bool) (resp []Response, err error) {
+	if c.conn.IsDisposed() {
+		return resp, errors.New("you cannot write on disposed connection")
+	}
+
+	resp, err = c.executeRequest(query, nil, nil, &sessionID, &commitSession)
+	return
+}
+
 // Execute formats a raw Gremlin query, sends it to Gremlin Server, and returns the result.
 func (c *Client) Execute(query string) (resp []Response, err error) {
 	if c.conn.IsDisposed() {

--- a/configuration.go
+++ b/configuration.go
@@ -41,11 +41,10 @@ func SetReadingWait(seconds int) DialerConfig {
 	}
 }
 
-
 //SetBufferSize sets the read/write buffer size
 func SetBufferSize(readBufferSize int, writeBufferSize int) DialerConfig {
 	return func(c *Ws) {
 		c.readBufSize = readBufferSize
-                c.writeBufSize = writeBufferSize
+		c.writeBufSize = writeBufferSize
 	}
 }

--- a/configuration.go
+++ b/configuration.go
@@ -40,3 +40,12 @@ func SetReadingWait(seconds int) DialerConfig {
 		c.readingWait = time.Duration(seconds) * time.Second
 	}
 }
+
+
+//SetBufferSize sets the read/write buffer size
+func SetBufferSize(readBufferSize int, writeBufferSize int) DialerConfig {
+	return func(c *Ws) {
+		c.readBufferSize = readBufferSize
+                c.writeBufferSize = writeBufferSize
+	}
+}

--- a/configuration.go
+++ b/configuration.go
@@ -45,7 +45,7 @@ func SetReadingWait(seconds int) DialerConfig {
 //SetBufferSize sets the read/write buffer size
 func SetBufferSize(readBufferSize int, writeBufferSize int) DialerConfig {
 	return func(c *Ws) {
-		c.readBufferSize = readBufferSize
-                c.writeBufferSize = writeBufferSize
+		c.readBufSize = readBufferSize
+                c.writeBufSize = writeBufferSize
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -38,8 +38,8 @@ type Ws struct {
 	writingWait  time.Duration
 	readingWait  time.Duration
 	timeout      time.Duration
-        readBufSize  int
-        writeBufSize int
+	readBufSize  int
+	writeBufSize int
 	quit         chan struct{}
 	sync.RWMutex
 }

--- a/connection.go
+++ b/connection.go
@@ -52,8 +52,8 @@ type auth struct {
 
 func (ws *Ws) connect() (err error) {
 	d := websocket.Dialer{
-		WriteBufferSize:  ws.readBufSize,
-		ReadBufferSize:   ws.writeBufSize,
+		WriteBufferSize:  ws.writeBufSize,
+		ReadBufferSize:   ws.readBufSize,
 		HandshakeTimeout: ws.timeout, // Timeout or else we'll hang forever and never fail on bad hosts.
 	}
 	ws.conn, _, err = d.Dial(ws.host, http.Header{})

--- a/connection.go
+++ b/connection.go
@@ -38,6 +38,8 @@ type Ws struct {
 	writingWait  time.Duration
 	readingWait  time.Duration
 	timeout      time.Duration
+        readBufSize  int
+        writeBufSize int
 	quit         chan struct{}
 	sync.RWMutex
 }
@@ -50,8 +52,8 @@ type auth struct {
 
 func (ws *Ws) connect() (err error) {
 	d := websocket.Dialer{
-		WriteBufferSize:  1000000,
-		ReadBufferSize:   8192,
+		WriteBufferSize:  ws.readBufSize,
+		ReadBufferSize:   ws.writeBufSize,
 		HandshakeTimeout: ws.timeout, // Timeout or else we'll hang forever and never fail on bad hosts.
 	}
 	ws.conn, _, err = d.Dial(ws.host, http.Header{})

--- a/connection.go
+++ b/connection.go
@@ -50,7 +50,7 @@ type auth struct {
 
 func (ws *Ws) connect() (err error) {
 	d := websocket.Dialer{
-		WriteBufferSize:  8192,
+		WriteBufferSize:  1000000,
 		ReadBufferSize:   8192,
 		HandshakeTimeout: ws.timeout, // Timeout or else we'll hang forever and never fail on bad hosts.
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rsrinathr/gremtune
+module github.com/elhampik/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elhampik/gremtune
+module github.com/rsrinathr/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/schwartzmx/gremtune
+module github.com/weinbergm/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/weinbergm/gremtune
+module github.com/schwartzmx/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/gorilla/websocket v1.2.0
 	github.com/pkg/errors v0.8.1
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/schwartzmx/gremtune
+module github.com/elhampik/gremtune
 
 require (
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/request.go
+++ b/request.go
@@ -21,14 +21,6 @@ type request struct {
 	Args      map[string]interface{} `json:"args"`
 }
 
-// sessionedRequest is a container for all evaluation request parameters to be sent to the Gremlin Server with session.
-type sessionedRequest struct {
-	RequestID string                 `json:"requestId"`
-	Op        string                 `json:"op"`
-	Processor string                 `json:"processor"`
-	Args      map[string]interface{} `json:"args"`
-}
-
 // prepareRequest packages a query and binding into the format that Gremlin Server accepts
 func prepareRequest(query string) (req request, id string, err error) {
 	var uuID uuid.UUID

--- a/request.go
+++ b/request.go
@@ -39,7 +39,7 @@ func prepareRequest(query string) (req request, id string, err error) {
 }
 
 // prepareRequest packages a query and binding into the format that Gremlin Server accepts
-func prepareRequestWithBindings(query string, bindings, rebindings map[string]string) (req request, id string, err error) {
+func prepareRequestWithBindings(query string, bindings, rebindings map[string]string, timeout int) (req request, id string, err error) {
 	var uuID uuid.UUID
 	uuID, _ = uuid.NewV4()
 	id = uuID.String()
@@ -53,12 +53,13 @@ func prepareRequestWithBindings(query string, bindings, rebindings map[string]st
 	req.Args["gremlin"] = query
 	req.Args["bindings"] = bindings
 	req.Args["rebindings"] = rebindings
+	req.Arg["scriptEvaluationTimeout"] = timeout
 
 	return
 }
 
 // prepareRequestWithSession packages a query and sessionID into the format that Gremlin Server accepts
-func prepareRequestWithSession(query string, sessionID string) (req request, id string, err error) {
+func prepareRequestWithSession(query string, sessionID string, timeout int) (req request, id string, err error) {
 
 	if len(sessionID) > 0 {
 		var uuID uuid.UUID
@@ -74,6 +75,7 @@ func prepareRequestWithSession(query string, sessionID string) (req request, id 
 		req.Args["manageTransaction"] = false
 		req.Args["session"] = sessionID
 		req.Args["batchSize"] = 64
+		req.Arg["scriptEvaluationTimeout"] = timeout
 	} else {
 		req, id, err = prepareRequest(query)
 	}

--- a/request.go
+++ b/request.go
@@ -65,7 +65,7 @@ func prepareRequestWithBindings(query string, bindings, rebindings map[string]st
 	return
 }
 
-// prepareRequest packages a query and binding into the format that Gremlin Server accepts
+// prepareRequestWithSession packages a query and sessionID into the format that Gremlin Server accepts
 func prepareRequestWithSession(query string, sessionID string) (req request, id string, err error) {
 
 	if len(sessionID) > 0 {

--- a/request.go
+++ b/request.go
@@ -82,7 +82,7 @@ func prepareRequestWithSession(query string, sessionID string) (req request, id 
 // prepareRequestWithSessionAndTimeout packages a query and sessionID into the format that Gremlin Server accepts
 func prepareRequestWithSessionAndTimeout(query string, sessionID string, timeout int) (req request, id string, err error) {
 
-	if len(sessionID) > 0 {
+	if len(sessionID) > 0 && timeout > 0 {
 		var uuID uuid.UUID
 		uuID, _ = uuid.NewV4()
 		id = uuID.String()
@@ -97,6 +97,8 @@ func prepareRequestWithSessionAndTimeout(query string, sessionID string, timeout
 		req.Args["session"] = sessionID
 		req.Args["batchSize"] = 64
 		req.Args["scriptEvaluationTimeout"] = timeout
+	} else if len(sessionID) > 0 {
+		req, id, err = prepareRequestWithSession(query, sessionID)
 	} else {
 		req, id, err = prepareRequest(query)
 	}

--- a/request.go
+++ b/request.go
@@ -39,7 +39,7 @@ func prepareRequest(query string) (req request, id string, err error) {
 }
 
 // prepareRequest packages a query and binding into the format that Gremlin Server accepts
-func prepareRequestWithBindings(query string, bindings, rebindings map[string]string, timeout int) (req request, id string, err error) {
+func prepareRequestWithBindings(query string, bindings, rebindings map[string]string) (req request, id string, err error) {
 	var uuID uuid.UUID
 	uuID, _ = uuid.NewV4()
 	id = uuID.String()
@@ -53,13 +53,11 @@ func prepareRequestWithBindings(query string, bindings, rebindings map[string]st
 	req.Args["gremlin"] = query
 	req.Args["bindings"] = bindings
 	req.Args["rebindings"] = rebindings
-	req.Arg["scriptEvaluationTimeout"] = timeout
-
 	return
 }
 
 // prepareRequestWithSession packages a query and sessionID into the format that Gremlin Server accepts
-func prepareRequestWithSession(query string, sessionID string, timeout int) (req request, id string, err error) {
+func prepareRequestWithSession(query string, sessionID string) (req request, id string, err error) {
 
 	if len(sessionID) > 0 {
 		var uuID uuid.UUID
@@ -98,7 +96,7 @@ func prepareRequestWithSessionAndTimeout(query string, sessionID string, timeout
 		req.Args["manageTransaction"] = false
 		req.Args["session"] = sessionID
 		req.Args["batchSize"] = 64
-		req.Arg["scriptEvaluationTimeout"] = timeout
+		req.Args["scriptEvaluationTimeout"] = timeout
 	} else {
 		req, id, err = prepareRequest(query)
 	}

--- a/request.go
+++ b/request.go
@@ -97,8 +97,24 @@ func prepareRequestWithSessionAndTimeout(query string, sessionID string, timeout
 		req.Args["session"] = sessionID
 		req.Args["batchSize"] = 64
 		req.Args["scriptEvaluationTimeout"] = timeout
-	} else if len(sessionID) > 0 {
+
+	} else if len(sessionID) <= 0 && timeout > 0 {
+		var uuID uuid.UUID
+		uuID, _ = uuid.NewV4()
+		id = uuID.String()
+
+		req.RequestID = id
+		req.Op = "eval"
+		req.Processor = ""
+
+		req.Args = make(map[string]interface{})
+		req.Args["language"] = "gremlin-groovy"
+		req.Args["gremlin"] = query
+		req.Args["scriptEvaluationTimeout"] = timeout
+
+	} else if len(sessionID) > 0 && timeout <= 0 {
 		req, id, err = prepareRequestWithSession(query, sessionID)
+
 	} else {
 		req, id, err = prepareRequest(query)
 	}

--- a/request.go
+++ b/request.go
@@ -75,6 +75,29 @@ func prepareRequestWithSession(query string, sessionID string, timeout int) (req
 		req.Args["manageTransaction"] = false
 		req.Args["session"] = sessionID
 		req.Args["batchSize"] = 64
+	} else {
+		req, id, err = prepareRequest(query)
+	}
+	return
+}
+
+// prepareRequestWithSessionAndTimeout packages a query and sessionID into the format that Gremlin Server accepts
+func prepareRequestWithSessionAndTimeout(query string, sessionID string, timeout int) (req request, id string, err error) {
+
+	if len(sessionID) > 0 {
+		var uuID uuid.UUID
+		uuID, _ = uuid.NewV4()
+		id = uuID.String()
+
+		req.RequestID = id
+		req.Op = "eval"
+		req.Processor = "session"
+		req.Args = make(map[string]interface{})
+		req.Args["language"] = "gremlin-groovy"
+		req.Args["gremlin"] = query
+		req.Args["manageTransaction"] = false
+		req.Args["session"] = sessionID
+		req.Args["batchSize"] = 64
 		req.Arg["scriptEvaluationTimeout"] = timeout
 	} else {
 		req, id, err = prepareRequest(query)

--- a/request_test.go
+++ b/request_test.go
@@ -33,6 +33,58 @@ func TestRequestPreparation(t *testing.T) {
 	}
 }
 
+// TestRequestPreparationWithSession tests the ability to package a query with session into a request struct for further manipulation
+func TestRequestPreparationWithSession(t *testing.T) {
+	query := "g.V(x)"
+	sessionID := "testSessionID"
+	req, id, err := prepareRequestWithSession(query, sessionID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedRequest := request{
+		RequestID: id,
+		Op:        "eval",
+		Processor: "session",
+		Args: map[string]interface{}{
+			"gremlin":           query,
+			"language":          "gremlin-groovy",
+			"session":           sessionID,
+			"manageTransaction": false,
+			"batchSize":         64,
+		},
+	}
+
+	if reflect.DeepEqual(req, expectedRequest) != true {
+		t.Fail()
+	}
+}
+
+// TestRequestPreparationWithSession tests the ability to package a query with session into a request struct for further manipulation
+func TestRequestPreparationCommitSession(t *testing.T) {
+	sessionID := "testSessionID"
+	req, id, err := prepareCommitSessionRequest(sessionID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedRequest := request{
+		RequestID: id,
+		Op:        "close",
+		Processor: "session",
+		Args: map[string]interface{}{
+			"language":          "gremlin-groovy",
+			"session":           sessionID,
+			"manageTransaction": false,
+			"force":             false,
+		},
+	}
+
+	if reflect.DeepEqual(req, expectedRequest) != true {
+		t.Fail()
+	}
+}
+
 // TestRequestPackaging tests the ability for gremtune to format a request using the established Gremlin Server WebSockets protocol for delivery to the server
 func TestRequestPackaging(t *testing.T) {
 	testRequest := request{

--- a/request_test.go
+++ b/request_test.go
@@ -37,7 +37,7 @@ func TestRequestPreparation(t *testing.T) {
 func TestRequestPreparationWithSessionAndTimeout(t *testing.T) {
 	query := "g.V(x)"
 	sessionID := "testSessionIDAndTimeout"
-	timeout := 300000
+	timeout := 85000
 	req, id, err := prepareRequestWithSessionAndTimeout(query, sessionID, timeout)
 	if err != nil {
 		t.Error(err)

--- a/request_test.go
+++ b/request_test.go
@@ -33,6 +33,35 @@ func TestRequestPreparation(t *testing.T) {
 	}
 }
 
+// TestRequestPreparationWithSessionAndTimeout tests the ability to package a query with session and timeout into a request struct for further manipulation
+func TestRequestPreparationWithSessionAndTimeout(t *testing.T) {
+	query := "g.V(x)"
+	sessionID := "testSessionIDAndTimeout"
+	timeout := 300000
+	req, id, err := prepareRequestWithSessionAndTimeout(query, sessionID, timeout)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedRequest := request{
+		RequestID: id,
+		Op:        "eval",
+		Processor: "session",
+		Args: map[string]interface{}{
+			"gremlin":                 query,
+			"language":                "gremlin-groovy",
+			"session":                 sessionID,
+			"manageTransaction":       false,
+			"batchSize":               64,
+			"scriptEvaluationTimeout": 85000,
+		},
+	}
+
+	if reflect.DeepEqual(req, expectedRequest) != true {
+		t.Fail()
+	}
+}
+
 // TestRequestPreparationWithSession tests the ability to package a query with session into a request struct for further manipulation
 func TestRequestPreparationWithSession(t *testing.T) {
 	query := "g.V(x)"

--- a/response.go
+++ b/response.go
@@ -158,13 +158,14 @@ func (c *Client) retrieveResponse(id string) (data []Response, err error) {
 			for i := range d {
 				data[i] = d[i].(Response)
 			}
-			close(resp.(chan error))
-			close(responseStatusNotifier.(chan int))
-			c.responseNotifier.Delete(id)
-			c.responseStatusNotifier.Delete(id)
-			c.deleteResponse(id)
 		}
 	}
+	close(resp.(chan error))
+	close(responseStatusNotifier.(chan int))
+	c.responseNotifier.Delete(id)
+	c.responseStatusNotifier.Delete(id)
+	c.deleteResponse(id)
+
 	return
 }
 


### PR DESCRIPTION
The request for queries with session Id was not supported by gremtune. This PR is adding the info to the request, so, Neptune will handle the queries with same session Id as one. the processor part of the request should be set to "session" and args part of the request should have a session Id for this purpose. the Op part of the request will be "eval" to add queries to a a session, and if set to "close", the session will get closed.